### PR TITLE
ensure only GETs are made to the API externally

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,10 @@ server {
     }
 
     location /v1 {
+        if ($request_method != GET) {
+            return 403;
+        }
+
         proxy_set_header   X-Real-IP $remote_addr;
         proxy_set_header   Host      $http_host;
         proxy_pass         http://127.0.0.1:4000;


### PR DESCRIPTION
As far as I can tell, the API is the only service exposed from Docker (via nginx), but this adds an extra layer of protection to prevent external modification.